### PR TITLE
Fix error handling

### DIFF
--- a/__tests__/compose.test.ts
+++ b/__tests__/compose.test.ts
@@ -10,6 +10,7 @@ jest.mock('@actions/exec', () => ({
 const OLD_ENV = process.env;
 beforeEach(() => {
   process.env = {...OLD_ENV};
+  mocked(exec).mockReset();
 });
 
 afterEach(() => {
@@ -34,9 +35,50 @@ describe('run docker-compose', () => {
       projectName: projectName
     };
 
+    const mockExec = mocked(exec);
+    mockExec.mockResolvedValue(0);
+
     await runCompose(command, [], context);
 
+    const calls = mockExec.mock.calls;
+    expect(calls.length).toBe(1);
+    const expectedArgs: string[] = [
+      '-f',
+      context.composeFiles[0],
+      '-p',
+      projectName,
+      command
+    ];
+    expect(mockExec).toHaveBeenCalledWith(
+      'docker-compose',
+      expectedArgs,
+      undefined
+    );
+  });
+
+  test('exec returns non-zero code', async () => {
+    const command = 'build';
+    const projectName = 'test-name';
+    const context: Context = {
+      composeFiles: ['docker-compose.ci.yml'],
+      serviceName: 'test',
+      composeCommand: 'up',
+      composeArguments: ['--abort-on-container-exit'],
+      runCommand: [],
+      build: true,
+      buildArgs: [],
+      push: false,
+      postCommand: ['down --remove-orphans --volumes', 'rm -f'],
+      isPost: false,
+      projectName: projectName
+    };
+
     const mockExec = mocked(exec);
+    mockExec.mockResolvedValue(1);
+
+    const returnValue = await runCompose(command, [], context);
+
+    expect(returnValue).toBe(1);
     const calls = mockExec.mock.calls;
     expect(calls.length).toBe(1);
     const expectedArgs: string[] = [
@@ -70,9 +112,11 @@ describe('run docker-compose', () => {
       projectName: projectName
     };
 
+    const mockExec = mocked(exec);
+    mockExec.mockResolvedValue(0);
+
     await runCompose(command, [], context);
 
-    const mockExec = mocked(exec);
     const calls = mockExec.mock.calls;
     expect(calls.length).toBe(1);
     const expectedArgs: string[] = [
@@ -108,9 +152,11 @@ describe('run docker-compose', () => {
       projectName: projectName
     };
 
+    const mockExec = mocked(exec);
+    mockExec.mockResolvedValue(0);
+
     await runCompose(command, [], context);
 
-    const mockExec = mocked(exec);
     const expectedArgs: string[] = [
       '-f',
       context.composeFiles[0],
@@ -145,9 +191,11 @@ describe('run docker-compose', () => {
       projectName: projectName
     };
 
+    const mockExec = mocked(exec);
+    mockExec.mockResolvedValue(0);
+
     await runCompose(command, args, context);
 
-    const mockExec = mocked(exec);
     const expectedArgs: string[] = [
       '-f',
       context.composeFiles[0],
@@ -239,6 +287,40 @@ describe('Main action entrypoint', () => {
       ],
       expectedOptions
     ]);
+  });
+
+  test('compose exits with code 1', async () => {
+    const projectName = 'test-name';
+    const serviceName = 'test-service';
+    const context: Context = {
+      composeFiles: ['docker-compose.ci.yml'],
+      serviceName,
+      composeCommand: 'up',
+      composeArguments: ['--abort-on-container-exit'],
+      runCommand: ['ignored'],
+      build: true,
+      buildArgs: [],
+      push: false,
+      postCommand: ['down --remove-orphans --volumes', 'rm -f'],
+      isPost: false,
+      projectName: projectName
+    };
+    const containerId = 'abc123';
+
+    const mockExec = mocked(exec);
+    mockExec.mockImplementation(async (cmd, args, options): Promise<number> => {
+      if (args && args.includes('up')) {
+        return 1;
+      }
+      if (options && options.listeners && options.listeners.stdout) {
+        options.listeners.stdout(new Buffer(`${containerId}\n`));
+      }
+      return 0;
+    });
+
+    expect(runAction(context)).rejects.toThrow(
+      new ComposeError('Error: docker-compose exited with code 1', containerId)
+    );
   });
 
   test('run action with build and build args', async () => {

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -17,7 +17,7 @@ export async function runCompose(
   args: string[],
   context: Context,
   execOptions?: exec.ExecOptions
-): Promise<void> {
+): Promise<number> {
   const composeArgs = [];
   for (const part of context.composeFiles) {
     composeArgs.push('-f', part);
@@ -29,7 +29,7 @@ export async function runCompose(
   for (const part of args) {
     composeArgs.push(part);
   }
-  await exec.exec('docker-compose', composeArgs, execOptions);
+  return await exec.exec('docker-compose', composeArgs, execOptions);
 }
 
 export async function getContainerId(context: Context): Promise<string | null> {
@@ -86,7 +86,10 @@ export async function runAction(context: Context): Promise<string | null> {
     }
   }
   try {
-    await runCompose(context.composeCommand, args, context);
+    const exitCode = await runCompose(context.composeCommand, args, context);
+    if (exitCode !== 0) {
+      throw new ComposeError(`docker-compose exited with code ${exitCode}`, null);
+    }
   } catch (e) {
     const containerId = await getContainerId(context);
     throw new ComposeError(`${e}`, containerId);

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -88,7 +88,10 @@ export async function runAction(context: Context): Promise<string | null> {
   try {
     const exitCode = await runCompose(context.composeCommand, args, context);
     if (exitCode !== 0) {
-      throw new ComposeError(`docker-compose exited with code ${exitCode}`, null);
+      throw new ComposeError(
+        `docker-compose exited with code ${exitCode}`,
+        null
+      );
     }
   } catch (e) {
     const containerId = await getContainerId(context);


### PR DESCRIPTION
If actions `exec` returns a non-zero exit code, but doesn't raise an error we should still error the action