### PR TITLE
renovate: automerge node types patch releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -112,6 +112,22 @@
         "patch",
         "renovate-deps"
       ]
+    },
+    {
+      "depTypeList":[
+        "devDependencies"
+      ],
+      "matchUpdateTypes":[
+        "patch"
+      ],
+      "matchPackagePrefixes":[
+        "@types"
+      ],
+      "labels":[
+        "no release",
+        "patch"
+      ],
+      "automerge": true
     }
   ],
   "github-actions": {

--- a/renovate.json
+++ b/renovate.json
@@ -114,18 +114,17 @@
       ]
     },
     {
-      "depTypeList":[
+      "depTypeList": [
         "devDependencies"
       ],
-      "matchUpdateTypes":[
+      "matchUpdateTypes": [
         "patch"
       ],
-      "matchPackagePrefixes":[
+      "matchPackagePrefixes": [
         "@types"
       ],
-      "labels":[
-        "no release",
-        "patch"
+      "labels": [
+        "no release"
       ],
       "automerge": true
     }


### PR DESCRIPTION
Trying to reduce renovate approval requests by auto merging `@types/*` node packages.

Testing:

```
$ renovate --platform=local
(node:96927) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 INFO: Repository started (repository=local)
       "renovateVersion": "37.148.0"
 INFO: Dependency extraction complete (repository=local)
       "stats": {
         "managers": {
           "docker-compose": {"fileCount": 1, "depCount": 0},
           "dockerfile": {"fileCount": 1, "depCount": 1},
           "github-actions": {"fileCount": 3, "depCount": 22},
           "npm": {"fileCount": 1, "depCount": 17}
         },
         "total": {"fileCount": 6, "depCount": 40}
       }
 WARN: GitHub token is required for some dependencies (repository=local)
       "githubDeps": ["smartlyio/check-versioning-action", "actions/checkout", "actions/setup-node"]
 INFO: Repository finished (repository=local)
       "cloned": undefined,
       "durationMs": 1633
```