### PR TITLE
support mount secret for docker compose action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,8 +55,8 @@ inputs:
       Each secret is mounted during build but not included in the final image.
       e.g:
         build-secrets: |
-          SECRET1=${{ secrets.SECRET1_VALUE }}
-          SECRET2=${{ secrets.SECRET2_VALUE }}
+          SECRET1=VALUE
+          SECRET2=VALUE
 
     required: false
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,17 @@ inputs:
           ARG2=other
     required: false
 
+  build-secrets:
+    description: |
+      Secrets to pass to docker compose build, as a newline separated list.
+      Each secret is mounted during build but not included in the final image.
+      e.g:
+        build-secrets: |
+          SECRET1=${{ secrets.SECRET1_VALUE }}
+          SECRET2=${{ secrets.SECRET2_VALUE }}
+
+    required: false
+
   registry-cache:
     description: Domain name of a proxying cache to dockerhub
     required: false

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -57,6 +57,8 @@ export async function runCompose(
   context: Context,
   execOptions?: exec.ExecOptions
 ): Promise<number> {
+  process.env.DOCKER_BUILDKIT = '1';
+  process.env.COMPOSE_DOCKER_CLI_BUILD = '1';
   const composeArgs = [];
   for (const part of context.composeFiles) {
     composeArgs.push('-f', part);
@@ -68,6 +70,12 @@ export async function runCompose(
   for (const part of args) {
     composeArgs.push(part);
   }
+  const options: exec.ExecOptions = execOptions || {};
+  options.env = {
+    ...process.env,
+    DOCKER_BUILDKIT: '1',
+    COMPOSE_DOCKER_CLI_BUILD: '1'
+  };
   const dockerCompose = await composeCommand.get();
   return await exec.exec(dockerCompose, composeArgs, execOptions);
 }

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -134,7 +134,7 @@ export async function runAction(context: Context): Promise<string | null> {
   if (context.build) {
     await runCompose(
       'build',
-      [...context.buildArgs, ...serviceNameArgs],
+      [...context.buildArgs, ...context.buildSecrets, ...serviceNameArgs],
       context
     );
   }


### PR DESCRIPTION
This PR follows issue in [slack thread](https://smartlyio.slack.com/archives/C013995RB9V/p1744758002334109?thread_ts=1743636797.995839&cid=C013995RB9V)

Here are some changes:
- Add build-secrets input parameter to handle and pass secrets to docker compose action
- Add tests